### PR TITLE
Implement onboarding wizard and fix delete API bugs

### DIFF
--- a/app/src/app/api/banks/route.ts
+++ b/app/src/app/api/banks/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { getAuthenticatedClient } from "@/lib/db";
+
+export async function GET() {
+  const { userId, supabase } = await getAuthenticatedClient();
+  if (!userId || !supabase) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from("popular_banks")
+      .select("id, name")
+      .order("sort_order", { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ banks: data || [] });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: error.message || "Failed to fetch banks" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/src/app/api/snapshots/[id]/route.test.ts
+++ b/app/src/app/api/snapshots/[id]/route.test.ts
@@ -28,8 +28,8 @@ describe("/api/snapshots/[id] route", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 404 when snapshot missing", async () => {
-    const eqFinal = vi.fn().mockResolvedValue({ error: null, count: 0 });
+  it("returns 200 even when snapshot missing (idempotent delete)", async () => {
+    const eqFinal = vi.fn().mockResolvedValue({ error: null });
     const eqFirst = vi.fn().mockReturnValue({ eq: eqFinal });
     const deleteFn = vi.fn().mockReturnValue({ eq: eqFirst });
     const sb = { from: vi.fn(() => ({ delete: deleteFn })) };
@@ -37,6 +37,6 @@ describe("/api/snapshots/[id] route", () => {
     const { DELETE } = await import("./route");
     const req = jsonRequest("http://test/api/snapshots/1", "DELETE");
     const res = await DELETE(req as never, { params: Promise.resolve({ id: "1" }) });
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(200);
   });
 });

--- a/app/src/app/api/snapshots/[id]/route.ts
+++ b/app/src/app/api/snapshots/[id]/route.ts
@@ -13,7 +13,7 @@ export async function DELETE(
   try {
     const { id } = await params;
 
-    const { error, count } = await supabase
+    const { error } = await supabase
       .from("snapshots")
       .delete()
       .eq("id", id)
@@ -21,10 +21,6 @@ export async function DELETE(
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    if (!count || count === 0) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
     return NextResponse.json({ success: true });

--- a/app/src/app/api/statements/[id]/route.ts
+++ b/app/src/app/api/statements/[id]/route.ts
@@ -85,7 +85,7 @@ export async function DELETE(
   try {
     const { id } = await params;
 
-    const { error, count } = await supabase
+    const { error } = await supabase
       .from("statements")
       .delete()
       .eq("id", id)
@@ -93,10 +93,6 @@ export async function DELETE(
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    if (!count || count === 0) {
-      return NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
     return NextResponse.json({ success: true });

--- a/app/src/app/api/statements/route.ts
+++ b/app/src/app/api/statements/route.ts
@@ -35,6 +35,28 @@ export async function GET(request: NextRequest) {
   }
 }
 
+export async function DELETE() {
+  const { userId, supabase } = await getAuthenticatedClient();
+  if (!userId || !supabase) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const { error } = await supabase
+      .from("statements")
+      .delete()
+      .eq("user_id", userId);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || "Failed to delete statements" }, { status: 500 });
+  }
+}
+
 export async function POST(request: NextRequest) {
   const { userId, supabase } = await getAuthenticatedClient();
   if (!userId || !supabase) {

--- a/app/src/app/dashboard/page.tsx
+++ b/app/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ import { DashboardPageShell } from "@/components/DashboardPageShell";
 import { useNetWorthHistory } from "@/hooks/useNetWorthHistory";
 import { useFinancialGoals } from "@/hooks/useFinancialGoals";
 import { useUserProfile } from "@/hooks/useUserProfile";
-import { FirstSnapshotOnboarding } from "@/components/FirstSnapshotOnboarding";
+import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
 import {
   LineChart,
   Line,
@@ -210,7 +210,7 @@ export default function DashboardHub() {
   // --- Onboarding: no snapshots yet, not dismissed -------------------------
   if (allLoaded && !hasSnapshots && !dismissed) {
     return (
-      <FirstSnapshotOnboarding
+      <OnboardingWizard
         firstName={firstName}
         onDismiss={() => setDismissed(true)}
       />

--- a/app/src/app/dashboard/snapshot/page.tsx
+++ b/app/src/app/dashboard/snapshot/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { StatementEntry, Category, ExtractedEntry, UploadedDocument } from "@/types";
 import { useStatements } from "@/hooks/useStatements";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -39,6 +39,14 @@ export default function SnapshotPage() {
   const { documents, addDocuments, deleteDocument, loaded: documentsLoaded } = useDocuments();
   const { saveSnapshot, snapshots, deleteSnapshot } = useNetWorthHistory();
 
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<string[]>([]);
+
+  const workingStatements = statements.filter((s) => !pendingDeleteIds.includes(s.id));
+
+  const handleLocalDelete = useCallback((id: string) => {
+    setPendingDeleteIds((prev) => [...prev, id]);
+  }, []);
+
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogDefaultCategory, setDialogDefaultCategory] = useState<Category>("asset");
   const [editingEntry, setEditingEntry] = useState<StatementEntry | null>(null);
@@ -53,7 +61,7 @@ export default function SnapshotPage() {
   const [snapshotStatus, setSnapshotStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [profileErrors, setProfileErrors] = useState<Record<string, string>>({});
 
-  const { totalAssets, totalLiabilities, netWorth } = computeTotals(statements);
+  const { totalAssets, totalLiabilities, netWorth } = computeTotals(workingStatements);
 
   function openAddDialog(category: Category) {
     setEditingEntry(null);
@@ -114,13 +122,13 @@ export default function SnapshotPage() {
     setExtractionResults([]);
   }
 
-  function handleSaveSnapshot() {
+  async function handleSaveSnapshot() {
     if (!profile.asOnDate) {
       setSnapshotStatus({ type: "error", message: "Set a snapshot date before saving." });
       setTimeout(() => setSnapshotStatus(null), 4000);
       return;
     }
-    if (statements.length === 0) {
+    if (workingStatements.length === 0) {
       setSnapshotStatus({ type: "error", message: "Add at least one entry before saving." });
       setTimeout(() => setSnapshotStatus(null), 4000);
       return;
@@ -130,7 +138,14 @@ export default function SnapshotPage() {
       const confirmed = window.confirm(`A snapshot for ${profile.asOnDate} already exists. Overwrite it?`);
       if (!confirmed) return;
     }
-    saveSnapshot({ date: profile.asOnDate, totalAssets, totalLiabilities, netWorth, entries: statements });
+
+    // Flush pending deletions to DB
+    for (const id of pendingDeleteIds) {
+      await deleteStatement(id);
+    }
+    setPendingDeleteIds([]);
+
+    saveSnapshot({ date: profile.asOnDate, totalAssets, totalLiabilities, netWorth, entries: workingStatements });
     setSnapshotStatus({ type: "success", message: `Snapshot saved for ${profile.asOnDate}.` });
     setTimeout(() => setSnapshotStatus(null), 4000);
   }
@@ -141,12 +156,12 @@ export default function SnapshotPage() {
     if (!profile.asOnDate) errors.asOnDate = "Snapshot date is required";
     setProfileErrors(errors);
     if (Object.keys(errors).length > 0) return;
-    if (statements.length === 0) {
+    if (workingStatements.length === 0) {
       setSnapshotStatus({ type: "error", message: "Add at least one entry to generate a certificate." });
       setTimeout(() => setSnapshotStatus(null), 4000);
       return;
     }
-    generateNetWorthPdf(profile, statements);
+    generateNetWorthPdf(profile, workingStatements);
   }
 
   if (!statementsLoaded || !profileLoaded || !documentsLoaded) {
@@ -215,9 +230,9 @@ export default function SnapshotPage() {
 
           {/* ── Asset & Liability lists ── */}
           <StatementList
-            statements={statements}
+            statements={workingStatements}
             onEdit={openEditDialog}
-            onDelete={deleteStatement}
+            onDelete={handleLocalDelete}
             onAddAsset={() => openAddDialog("asset")}
             onAddLiability={() => openAddDialog("liability")}
           />
@@ -225,7 +240,7 @@ export default function SnapshotPage() {
           {/* ── BELOW: NetWorth Summary + Snapshot Details side-by-side ── */}
           <div className="grid grid-cols-1 gap-5 items-stretch lg:grid-cols-[0.7fr_0.3fr]">
             {/* Left: NetWorth Summary */}
-            <NetWorthSummary className="h-full" statements={statements} />
+            <NetWorthSummary className="h-full" statements={workingStatements} />
             
             {/* Right: Snapshot Details with buttons below */}
             <div className="flex h-full flex-col gap-4">

--- a/app/src/components/onboarding/BankSavingsStep.tsx
+++ b/app/src/components/onboarding/BankSavingsStep.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { useBanks } from "@/hooks/useBanks";
+import type { StatementEntry } from "@/types";
+
+interface BankAccount {
+  bank: string;
+  isOther: boolean;
+  customBank: string;
+  balance: string;
+}
+
+const emptyAccount = (): BankAccount => ({
+  bank: "",
+  isOther: false,
+  customBank: "",
+  balance: "",
+});
+
+interface BankSavingsStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function BankSavingsStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: BankSavingsStepProps) {
+  const { banks, loaded } = useBanks();
+
+  const [accounts, setAccounts] = useState<BankAccount[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => {
+        const bankName = e.description;
+        const isKnown = banks.some((b) => b.name === bankName);
+        return {
+          bank: isKnown ? bankName : "Other",
+          isOther: !isKnown,
+          customBank: isKnown ? "" : bankName,
+          balance: String(e.closingBalance),
+        };
+      });
+    }
+    return [emptyAccount()];
+  });
+
+  const updateAccount = (index: number, updates: Partial<BankAccount>) => {
+    setAccounts((prev) =>
+      prev.map((a, i) => (i === index ? { ...a, ...updates } : a))
+    );
+  };
+
+  const addAccount = () => setAccounts((prev) => [...prev, emptyAccount()]);
+
+  const removeAccount = (index: number) => {
+    setAccounts((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = accounts
+      .filter((a) => {
+        const name = a.isOther ? a.customBank.trim() : a.bank;
+        return name && parseFloat(a.balance) > 0;
+      })
+      .map((a) => ({
+        statementType: "Savings Bank Account",
+        description: a.isOther ? a.customBank.trim() : a.bank,
+        category: "asset" as const,
+        closingBalance: parseFloat(a.balance),
+        ownershipPercentage: 100,
+      }));
+    onNext(entries);
+  };
+
+  const handleSkip = () => onNext([]);
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Let&apos;s start with your bank savings
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Add each bank account you hold with its closing balance.
+      </p>
+
+      <div className="space-y-4">
+        {accounts.map((account, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Account {index + 1}
+              </span>
+              {accounts.length > 1 && (
+                <button
+                  onClick={() => removeAccount(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Bank
+                </label>
+                {loaded ? (
+                  <select
+                    value={account.isOther ? "Other" : account.bank}
+                    onChange={(e) => {
+                      const val = e.target.value;
+                      if (val === "Other") {
+                        updateAccount(index, {
+                          bank: "Other",
+                          isOther: true,
+                        });
+                      } else {
+                        updateAccount(index, {
+                          bank: val,
+                          isOther: false,
+                          customBank: "",
+                        });
+                      }
+                    }}
+                    className="min-h-11 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm shadow-sm transition-all outline-none hover:border-primary/35 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                  >
+                    <option value="">Select a bank</option>
+                    {banks.map((b) => (
+                      <option key={b.id} value={b.name}>
+                        {b.name}
+                      </option>
+                    ))}
+                    <option value="Other">Other</option>
+                  </select>
+                ) : (
+                  <Input
+                    placeholder="Enter bank name"
+                    value={account.customBank}
+                    onChange={(e) =>
+                      updateAccount(index, {
+                        customBank: e.target.value,
+                        isOther: true,
+                      })
+                    }
+                  />
+                )}
+                {account.isOther && loaded && (
+                  <Input
+                    className="mt-2"
+                    placeholder="Enter bank name"
+                    value={account.customBank}
+                    onChange={(e) =>
+                      updateAccount(index, { customBank: e.target.value })
+                    }
+                  />
+                )}
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Closing Balance (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={account.balance}
+                  onChange={(e) =>
+                    updateAccount(index, { balance: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addAccount}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another account
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleSkip}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/CreditCardsStep.tsx
+++ b/app/src/components/onboarding/CreditCardsStep.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { StatementEntry } from "@/types";
+
+interface CardRow {
+  description: string;
+  amount: string;
+}
+
+const emptyRow = (): CardRow => ({ description: "", amount: "" });
+
+interface CreditCardsStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function CreditCardsStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: CreditCardsStepProps) {
+  const [rows, setRows] = useState<CardRow[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => ({
+        description: e.description,
+        amount: String(e.closingBalance),
+      }));
+    }
+    return [emptyRow()];
+  });
+
+  const updateRow = (index: number, updates: Partial<CardRow>) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...updates } : r))
+    );
+  };
+
+  const addRow = () => setRows((prev) => [...prev, emptyRow()]);
+  const removeRow = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index));
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = rows
+      .filter((r) => r.description.trim() && parseFloat(r.amount) > 0)
+      .map((r) => ({
+        statementType: "Credit Card Outstanding",
+        description: r.description.trim(),
+        category: "liability" as const,
+        closingBalance: parseFloat(r.amount),
+        ownershipPercentage: 100,
+      }));
+    onNext(entries);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Any credit card balances you&apos;re carrying?
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Only outstanding balance, not your credit limit.
+      </p>
+
+      <div className="space-y-4">
+        {rows.map((row, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Card {index + 1}
+              </span>
+              {rows.length > 1 && (
+                <button
+                  onClick={() => removeRow(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Card Description
+                </label>
+                <Input
+                  placeholder="e.g. HDFC Regalia"
+                  value={row.description}
+                  onChange={(e) =>
+                    updateRow(index, { description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Outstanding Amount (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={row.amount}
+                  onChange={(e) =>
+                    updateRow(index, { amount: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addRow}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => onNext([])}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/DepositsStep.tsx
+++ b/app/src/components/onboarding/DepositsStep.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { StatementEntry } from "@/types";
+
+const DEPOSIT_TYPES = [
+  { label: "Fixed Deposit", statementType: "Fixed Deposit" },
+  { label: "PPF", statementType: "PPF" },
+  { label: "EPF", statementType: "Other Asset" },
+] as const;
+
+interface DepositRow {
+  type: string;
+  description: string;
+  amount: string;
+}
+
+const emptyRow = (): DepositRow => ({ type: "", description: "", amount: "" });
+
+interface DepositsStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function DepositsStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: DepositsStepProps) {
+  const [rows, setRows] = useState<DepositRow[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => {
+        const preset = DEPOSIT_TYPES.find(
+          (d) => d.statementType === e.statementType
+        );
+        return {
+          type: preset?.label || e.description,
+          description: e.description,
+          amount: String(e.closingBalance),
+        };
+      });
+    }
+    return [emptyRow()];
+  });
+
+  const updateRow = (index: number, updates: Partial<DepositRow>) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...updates } : r))
+    );
+  };
+
+  const addRow = () => setRows((prev) => [...prev, emptyRow()]);
+  const removeRow = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index));
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = rows
+      .filter((r) => r.type && parseFloat(r.amount) > 0)
+      .map((r) => {
+        const preset = DEPOSIT_TYPES.find((d) => d.label === r.type);
+        const isEPF = r.type === "EPF";
+        return {
+          statementType: preset?.statementType || "Other Asset",
+          description: isEPF ? "EPF" : r.description || r.type,
+          category: "asset" as const,
+          closingBalance: parseFloat(r.amount),
+          ownershipPercentage: 100,
+        };
+      });
+    onNext(entries);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Any fixed deposits or provident fund?
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Add your FDs, PPF, or EPF balances.
+      </p>
+
+      <div className="space-y-4">
+        {rows.map((row, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Entry {index + 1}
+              </span>
+              {rows.length > 1 && (
+                <button
+                  onClick={() => removeRow(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Type
+                </label>
+                <select
+                  value={row.type}
+                  onChange={(e) => updateRow(index, { type: e.target.value })}
+                  className="min-h-11 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm shadow-sm transition-all outline-none hover:border-primary/35 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="">Select type</option>
+                  {DEPOSIT_TYPES.map((d) => (
+                    <option key={d.label} value={d.label}>
+                      {d.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Description (optional)
+                </label>
+                <Input
+                  placeholder="e.g. SBI FD"
+                  value={row.description}
+                  onChange={(e) =>
+                    updateRow(index, { description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Amount (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={row.amount}
+                  onChange={(e) =>
+                    updateRow(index, { amount: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addRow}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => onNext([])}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/InvestmentsStep.tsx
+++ b/app/src/components/onboarding/InvestmentsStep.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { StatementEntry } from "@/types";
+
+const INVESTMENT_TYPES = [
+  { label: "Mutual Fund", statementType: "Mutual Fund" },
+  { label: "Stock Holdings", statementType: "Stock Holdings" },
+  { label: "Gold/Jewellery", statementType: "Gold/Jewellery" },
+] as const;
+
+interface InvestmentRow {
+  type: string;
+  description: string;
+  amount: string;
+}
+
+const emptyRow = (): InvestmentRow => ({
+  type: "",
+  description: "",
+  amount: "",
+});
+
+interface InvestmentsStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function InvestmentsStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: InvestmentsStepProps) {
+  const [rows, setRows] = useState<InvestmentRow[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => ({
+        type:
+          INVESTMENT_TYPES.find((t) => t.statementType === e.statementType)
+            ?.label || e.statementType,
+        description: e.description,
+        amount: String(e.closingBalance),
+      }));
+    }
+    return [emptyRow()];
+  });
+
+  const updateRow = (index: number, updates: Partial<InvestmentRow>) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...updates } : r))
+    );
+  };
+
+  const addRow = () => setRows((prev) => [...prev, emptyRow()]);
+  const removeRow = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index));
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = rows
+      .filter((r) => r.type && parseFloat(r.amount) > 0)
+      .map((r) => {
+        const preset = INVESTMENT_TYPES.find((t) => t.label === r.type);
+        return {
+          statementType: preset?.statementType || r.type,
+          description: r.description || r.type,
+          category: "asset" as const,
+          closingBalance: parseFloat(r.amount),
+          ownershipPercentage: 100,
+        };
+      });
+    onNext(entries);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Any investments?
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Mutual funds, stocks, gold — add them here.
+      </p>
+
+      <div className="space-y-4">
+        {rows.map((row, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Entry {index + 1}
+              </span>
+              {rows.length > 1 && (
+                <button
+                  onClick={() => removeRow(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Type
+                </label>
+                <select
+                  value={row.type}
+                  onChange={(e) => updateRow(index, { type: e.target.value })}
+                  className="min-h-11 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm shadow-sm transition-all outline-none hover:border-primary/35 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="">Select type</option>
+                  {INVESTMENT_TYPES.map((t) => (
+                    <option key={t.label} value={t.label}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Description (optional)
+                </label>
+                <Input
+                  placeholder="e.g. HDFC Balanced Fund"
+                  value={row.description}
+                  onChange={(e) =>
+                    updateRow(index, { description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Amount (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={row.amount}
+                  onChange={(e) =>
+                    updateRow(index, { amount: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addRow}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => onNext([])}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/LoansStep.tsx
+++ b/app/src/components/onboarding/LoansStep.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { StatementEntry } from "@/types";
+
+const LOAN_TYPES = [
+  "Home Loan",
+  "Personal Loan",
+  "Car Loan",
+  "Education Loan",
+] as const;
+
+interface LoanRow {
+  type: string;
+  description: string;
+  amount: string;
+}
+
+const emptyRow = (): LoanRow => ({ type: "", description: "", amount: "" });
+
+interface LoansStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function LoansStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: LoansStepProps) {
+  const [rows, setRows] = useState<LoanRow[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => ({
+        type: e.statementType,
+        description: e.description,
+        amount: String(e.closingBalance),
+      }));
+    }
+    return [emptyRow()];
+  });
+
+  const updateRow = (index: number, updates: Partial<LoanRow>) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...updates } : r))
+    );
+  };
+
+  const addRow = () => setRows((prev) => [...prev, emptyRow()]);
+  const removeRow = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index));
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = rows
+      .filter((r) => r.type && parseFloat(r.amount) > 0)
+      .map((r) => ({
+        statementType: r.type,
+        description: r.description || r.type,
+        category: "liability" as const,
+        closingBalance: parseFloat(r.amount),
+        ownershipPercentage: 100,
+      }));
+    onNext(entries);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Now let&apos;s record any loans
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Add outstanding loan balances.
+      </p>
+
+      <div className="space-y-4">
+        {rows.map((row, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Loan {index + 1}
+              </span>
+              {rows.length > 1 && (
+                <button
+                  onClick={() => removeRow(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Type
+                </label>
+                <select
+                  value={row.type}
+                  onChange={(e) => updateRow(index, { type: e.target.value })}
+                  className="min-h-11 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm shadow-sm transition-all outline-none hover:border-primary/35 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="">Select type</option>
+                  {LOAN_TYPES.map((t) => (
+                    <option key={t} value={t}>
+                      {t}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Description (optional)
+                </label>
+                <Input
+                  placeholder="e.g. HDFC Home Loan"
+                  value={row.description}
+                  onChange={(e) =>
+                    updateRow(index, { description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Outstanding Amount (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={row.amount}
+                  onChange={(e) =>
+                    updateRow(index, { amount: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addRow}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => onNext([])}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/OnboardingWizard.tsx
+++ b/app/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { useStatements } from "@/hooks/useStatements";
+import { useNetWorthHistory } from "@/hooks/useNetWorthHistory";
+import { computeTotals } from "@/lib/computations";
+import type { StatementEntry } from "@/types";
+import { WelcomeStep, type OnboardingPath } from "./WelcomeStep";
+import { BankSavingsStep } from "./BankSavingsStep";
+import { DepositsStep } from "./DepositsStep";
+import { InvestmentsStep } from "./InvestmentsStep";
+import { PropertyStep } from "./PropertyStep";
+import { LoansStep } from "./LoansStep";
+import { CreditCardsStep } from "./CreditCardsStep";
+import { SummaryStep } from "./SummaryStep";
+
+// ---------------------------------------------------------------------------
+// Step configuration
+// ---------------------------------------------------------------------------
+
+interface StepConfig {
+  id: string;
+  quickStart: boolean;
+}
+
+const STEPS: StepConfig[] = [
+  { id: "welcome", quickStart: true },
+  { id: "bank-savings", quickStart: true },
+  { id: "deposits", quickStart: false },
+  { id: "investments", quickStart: false },
+  { id: "property", quickStart: false },
+  { id: "loans", quickStart: true },
+  { id: "credit-cards", quickStart: true },
+  { id: "summary", quickStart: true },
+];
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface OnboardingWizardProps {
+  firstName: string;
+  onDismiss: () => void;
+}
+
+export function OnboardingWizard({
+  firstName,
+  onDismiss,
+}: OnboardingWizardProps) {
+  const { bulkAddStatements, deleteAllStatements } = useStatements();
+  const { saveSnapshot } = useNetWorthHistory();
+
+  const [path, setPath] = useState<OnboardingPath | null>(null);
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const [direction, setDirection] = useState(1);
+
+  // Entries keyed by step id
+  const [stepEntries, setStepEntries] = useState<
+    Record<string, Omit<StatementEntry, "id">[]>
+  >({});
+
+  // Filtered steps based on selected path
+  const activeSteps = useMemo(() => {
+    if (!path) return [STEPS[0]];
+    if (path === "quick") return STEPS.filter((s) => s.quickStart);
+    return STEPS;
+  }, [path]);
+
+  const currentStep = activeSteps[currentStepIndex];
+
+  // All accumulated entries
+  const allEntries = useMemo(
+    () => Object.values(stepEntries).flat(),
+    [stepEntries]
+  );
+
+  // Navigation
+  const goNext = useCallback(() => {
+    setDirection(1);
+    setCurrentStepIndex((prev) => Math.min(prev + 1, activeSteps.length - 1));
+  }, [activeSteps.length]);
+
+  const goBack = useCallback(() => {
+    setDirection(-1);
+    setCurrentStepIndex((prev) => Math.max(prev - 1, 0));
+  }, []);
+
+  // Handle step data submission
+  const handleStepData = useCallback(
+    (stepId: string, entries: Omit<StatementEntry, "id">[]) => {
+      setStepEntries((prev) => ({ ...prev, [stepId]: entries }));
+      goNext();
+    },
+    [goNext]
+  );
+
+  // Handle path selection from welcome step
+  const handleSelectPath = useCallback(
+    (selectedPath: OnboardingPath) => {
+      setPath(selectedPath);
+      setDirection(1);
+      setCurrentStepIndex(1);
+    },
+    []
+  );
+
+  // Auto-save handler for summary
+  const handleSave = useCallback(
+    async (data: {
+      entries: Omit<StatementEntry, "id">[];
+      totalAssets: number;
+      totalLiabilities: number;
+      netWorth: number;
+    }) => {
+      await deleteAllStatements();
+      if (data.entries.length > 0) {
+        await bulkAddStatements(data.entries);
+      }
+      const today = new Date().toISOString().split("T")[0];
+      await saveSnapshot({
+        date: today,
+        totalAssets: data.totalAssets,
+        totalLiabilities: data.totalLiabilities,
+        netWorth: data.netWorth,
+        entries: data.entries.map((e, i) => ({ ...e, id: `onboarding-${i}` })),
+      });
+    },
+    [deleteAllStatements, bulkAddStatements, saveSnapshot]
+  );
+
+  // After saving, navigate to dashboard by reloading current route
+  const handleGoToDashboard = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  // Progress (excluding welcome and summary from the count display)
+  const dataSteps = activeSteps.filter(
+    (s) => s.id !== "welcome" && s.id !== "summary"
+  );
+  const currentDataStepIndex = dataSteps.findIndex(
+    (s) => s.id === currentStep?.id
+  );
+  const showProgress =
+    currentStep?.id !== "welcome" && currentStep?.id !== "summary";
+
+  // Animation variants
+  const slideVariants = {
+    enter: (dir: number) => ({
+      x: dir > 0 ? 80 : -80,
+      opacity: 0,
+    }),
+    center: {
+      x: 0,
+      opacity: 1,
+    },
+    exit: (dir: number) => ({
+      x: dir > 0 ? -80 : 80,
+      opacity: 0,
+    }),
+  };
+
+  // Render current step
+  const renderStep = () => {
+    if (!currentStep) return null;
+
+    switch (currentStep.id) {
+      case "welcome":
+        return (
+          <WelcomeStep onSelectPath={handleSelectPath} onDismiss={onDismiss} />
+        );
+      case "bank-savings":
+        return (
+          <BankSavingsStep
+            initialEntries={stepEntries["bank-savings"] || []}
+            onNext={(entries) => handleStepData("bank-savings", entries)}
+            onBack={goBack}
+          />
+        );
+      case "deposits":
+        return (
+          <DepositsStep
+            initialEntries={stepEntries["deposits"] || []}
+            onNext={(entries) => handleStepData("deposits", entries)}
+            onBack={goBack}
+          />
+        );
+      case "investments":
+        return (
+          <InvestmentsStep
+            initialEntries={stepEntries["investments"] || []}
+            onNext={(entries) => handleStepData("investments", entries)}
+            onBack={goBack}
+          />
+        );
+      case "property":
+        return (
+          <PropertyStep
+            initialEntries={stepEntries["property"] || []}
+            onNext={(entries) => handleStepData("property", entries)}
+            onBack={goBack}
+          />
+        );
+      case "loans":
+        return (
+          <LoansStep
+            initialEntries={stepEntries["loans"] || []}
+            onNext={(entries) => handleStepData("loans", entries)}
+            onBack={goBack}
+          />
+        );
+      case "credit-cards":
+        return (
+          <CreditCardsStep
+            initialEntries={stepEntries["credit-cards"] || []}
+            onNext={(entries) => handleStepData("credit-cards", entries)}
+            onBack={goBack}
+          />
+        );
+      case "summary":
+        return (
+          <SummaryStep
+            entries={allEntries}
+            onSave={handleSave}
+            onGoToDashboard={handleGoToDashboard}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-12">
+      <div className="w-full max-w-2xl">
+        {/* Progress bar */}
+        {showProgress && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-8"
+          >
+            <div className="mb-2 flex items-center justify-between text-xs text-foreground/40">
+              <span>
+                Step {currentDataStepIndex + 1} of {dataSteps.length}
+              </span>
+              <span>
+                {path === "quick" ? "Quick Start" : "Complete Picture"}
+              </span>
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+              <motion.div
+                className="h-full rounded-full bg-primary"
+                initial={false}
+                animate={{
+                  width: `${
+                    ((currentDataStepIndex + 1) / dataSteps.length) * 100
+                  }%`,
+                }}
+                transition={{ duration: 0.3, ease: "easeInOut" }}
+              />
+            </div>
+          </motion.div>
+        )}
+
+        {/* Step content with AnimatePresence */}
+        <div className="surface-card relative overflow-hidden rounded-3xl border border-white/8 p-8 shadow-glow sm:p-10">
+          {/* Welcome badge */}
+          {currentStep?.id === "welcome" && (
+            <div className="mb-7">
+              <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-4 py-1.5 text-sm font-semibold text-primary">
+                Welcome, {firstName}
+              </span>
+            </div>
+          )}
+
+          <AnimatePresence mode="wait" custom={direction}>
+            <motion.div
+              key={currentStep?.id}
+              custom={direction}
+              variants={slideVariants}
+              initial="enter"
+              animate="center"
+              exit="exit"
+              transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+            >
+              {renderStep()}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        {/* Footer */}
+        <p className="mt-6 text-center text-xs text-foreground/30">
+          Your data stays private · You can edit later from the Snapshot page
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/PropertyStep.tsx
+++ b/app/src/components/onboarding/PropertyStep.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Plus, Trash2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import type { StatementEntry } from "@/types";
+
+const PROPERTY_TYPES = [
+  { label: "Real Estate", statementType: "Real Estate" },
+  { label: "Vehicle", statementType: "Other Asset" },
+] as const;
+
+interface PropertyRow {
+  type: string;
+  description: string;
+  amount: string;
+}
+
+const emptyRow = (): PropertyRow => ({
+  type: "",
+  description: "",
+  amount: "",
+});
+
+interface PropertyStepProps {
+  initialEntries: Omit<StatementEntry, "id">[];
+  onNext: (entries: Omit<StatementEntry, "id">[]) => void;
+  onBack: () => void;
+}
+
+export function PropertyStep({
+  initialEntries,
+  onNext,
+  onBack,
+}: PropertyStepProps) {
+  const [rows, setRows] = useState<PropertyRow[]>(() => {
+    if (initialEntries.length > 0) {
+      return initialEntries.map((e) => ({
+        type:
+          e.statementType === "Real Estate" ? "Real Estate" : "Vehicle",
+        description: e.description,
+        amount: String(e.closingBalance),
+      }));
+    }
+    return [emptyRow()];
+  });
+
+  const updateRow = (index: number, updates: Partial<PropertyRow>) => {
+    setRows((prev) =>
+      prev.map((r, i) => (i === index ? { ...r, ...updates } : r))
+    );
+  };
+
+  const addRow = () => setRows((prev) => [...prev, emptyRow()]);
+  const removeRow = (index: number) =>
+    setRows((prev) => prev.filter((_, i) => i !== index));
+
+  const handleNext = () => {
+    const entries: Omit<StatementEntry, "id">[] = rows
+      .filter((r) => r.type && r.description.trim() && parseFloat(r.amount) > 0)
+      .map((r) => {
+        const preset = PROPERTY_TYPES.find((t) => t.label === r.type);
+        return {
+          statementType: preset?.statementType || "Other Asset",
+          description: r.description.trim(),
+          category: "asset" as const,
+          closingBalance: parseFloat(r.amount),
+          ownershipPercentage: 100,
+        };
+      });
+    onNext(entries);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <h2 className="mb-1 text-2xl font-semibold text-foreground">
+        Do you own any property or vehicles?
+      </h2>
+      <p className="mb-8 text-sm text-foreground/45">
+        Add real estate or vehicles with their current fair market value.
+      </p>
+
+      <div className="space-y-4">
+        {rows.map((row, index) => (
+          <motion.div
+            key={index}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex flex-col gap-3 rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-medium text-foreground/40">
+                Entry {index + 1}
+              </span>
+              {rows.length > 1 && (
+                <button
+                  onClick={() => removeRow(index)}
+                  className="text-foreground/30 hover:text-destructive transition-colors"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Type
+                </label>
+                <select
+                  value={row.type}
+                  onChange={(e) => updateRow(index, { type: e.target.value })}
+                  className="min-h-11 w-full rounded-xl border border-input bg-card px-3 py-2 text-sm shadow-sm transition-all outline-none hover:border-primary/35 focus:border-primary focus:ring-2 focus:ring-primary/20"
+                >
+                  <option value="">Select type</option>
+                  {PROPERTY_TYPES.map((t) => (
+                    <option key={t.label} value={t.label}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Description
+                </label>
+                <Input
+                  placeholder={
+                    row.type === "Vehicle"
+                      ? "e.g. Honda City 2022"
+                      : "e.g. 2BHK Pune"
+                  }
+                  value={row.description}
+                  onChange={(e) =>
+                    updateRow(index, { description: e.target.value })
+                  }
+                />
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-foreground/50">
+                  Fair Market Value (₹)
+                </label>
+                <Input
+                  type="number"
+                  min="0"
+                  placeholder="0"
+                  value={row.amount}
+                  onChange={(e) =>
+                    updateRow(index, { amount: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+
+      <button
+        onClick={addRow}
+        className="mt-4 flex items-center gap-2 self-start text-sm font-medium text-primary/70 transition-colors hover:text-primary"
+      >
+        <Plus className="h-4 w-4" />
+        Add another
+      </button>
+
+      <div className="mt-8 flex items-center justify-between">
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          Back
+        </Button>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => onNext([])}
+            className="text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+          >
+            I don&apos;t have any
+          </button>
+          <Button onClick={handleNext}>Next</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/SummaryStep.tsx
+++ b/app/src/components/onboarding/SummaryStep.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useEffect, useState, useRef, useCallback } from "react";
+import { motion } from "framer-motion";
+import { CheckCircle2, AlertCircle, PartyPopper } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { computeTotals } from "@/lib/computations";
+import { formatINR } from "@/lib/computations";
+import type { StatementEntry } from "@/types";
+
+interface SummaryStepProps {
+  entries: Omit<StatementEntry, "id">[];
+  onSave: (data: {
+    entries: Omit<StatementEntry, "id">[];
+    totalAssets: number;
+    totalLiabilities: number;
+    netWorth: number;
+  }) => Promise<void>;
+  onGoToDashboard: () => void;
+}
+
+export function SummaryStep({
+  entries,
+  onSave,
+  onGoToDashboard,
+}: SummaryStepProps) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const hasSaved = useRef(false);
+
+  const totals = computeTotals(
+    entries.map((e, i) => ({ ...e, id: `temp-${i}` }))
+  );
+
+  const doSave = useCallback(async () => {
+    if (hasSaved.current || entries.length === 0) return;
+    hasSaved.current = true;
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        entries,
+        totalAssets: totals.totalAssets,
+        totalLiabilities: totals.totalLiabilities,
+        netWorth: totals.netWorth,
+      });
+      setSaved(true);
+    } catch (err: any) {
+      setError(err.message || "Failed to save snapshot");
+      hasSaved.current = false;
+    } finally {
+      setSaving(false);
+    }
+  }, [entries, onSave, totals]);
+
+  useEffect(() => {
+    doSave();
+  }, [doSave]);
+
+  const assetEntries = entries.filter((e) => e.category === "asset");
+  const liabilityEntries = entries.filter((e) => e.category === "liability");
+
+  return (
+    <div className="flex flex-col items-center text-center">
+      {saved && (
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: "spring", stiffness: 200, damping: 15 }}
+          className="mb-6"
+        >
+          <PartyPopper className="h-16 w-16 text-primary" />
+        </motion.div>
+      )}
+
+      <h2 className="mb-2 text-2xl font-semibold text-foreground sm:text-3xl">
+        {saved
+          ? "Here's your financial snapshot!"
+          : saving
+          ? "Saving your snapshot..."
+          : "Your financial summary"}
+      </h2>
+
+      {error && (
+        <div className="mb-6 flex items-center gap-2 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <span>{error}</span>
+          <Button
+            variant="ghost"
+            size="xs"
+            onClick={() => {
+              hasSaved.current = false;
+              doSave();
+            }}
+          >
+            Retry
+          </Button>
+        </div>
+      )}
+
+      <div className="mb-8 w-full max-w-md space-y-4">
+        {/* Net Worth Hero */}
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2 }}
+          className="rounded-2xl border border-primary/30 bg-primary/5 p-6"
+        >
+          <p className="text-xs font-bold uppercase tracking-widest text-primary/60">
+            Net Worth
+          </p>
+          <p className="mt-1 text-3xl font-bold tabular-nums text-foreground">
+            {formatINR(totals.netWorth)}
+          </p>
+        </motion.div>
+
+        {/* Assets / Liabilities */}
+        <div className="grid grid-cols-2 gap-4">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.3 }}
+            className="rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <p className="text-xs font-medium text-foreground/40">
+              Total Assets
+            </p>
+            <p className="mt-1 text-lg font-semibold tabular-nums text-success">
+              {formatINR(totals.totalAssets)}
+            </p>
+            <p className="mt-1 text-xs text-foreground/30">
+              {assetEntries.length} item{assetEntries.length !== 1 ? "s" : ""}
+            </p>
+          </motion.div>
+
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.4 }}
+            className="rounded-xl border border-white/8 bg-white/[0.02] p-4"
+          >
+            <p className="text-xs font-medium text-foreground/40">
+              Total Liabilities
+            </p>
+            <p className="mt-1 text-lg font-semibold tabular-nums text-destructive">
+              {formatINR(totals.totalLiabilities)}
+            </p>
+            <p className="mt-1 text-xs text-foreground/30">
+              {liabilityEntries.length} item
+              {liabilityEntries.length !== 1 ? "s" : ""}
+            </p>
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Confetti-like celebration dots */}
+      {saved && (
+        <div className="pointer-events-none absolute inset-0 overflow-hidden">
+          {Array.from({ length: 20 }).map((_, i) => (
+            <motion.div
+              key={i}
+              initial={{
+                opacity: 1,
+                x: "50%",
+                y: "40%",
+                scale: 0,
+              }}
+              animate={{
+                opacity: 0,
+                x: `${Math.random() * 100}%`,
+                y: `${Math.random() * 100}%`,
+                scale: Math.random() * 1.5 + 0.5,
+              }}
+              transition={{
+                duration: 1.5 + Math.random(),
+                delay: Math.random() * 0.5,
+                ease: "easeOut",
+              }}
+              className="absolute h-2 w-2 rounded-full"
+              style={{
+                backgroundColor: [
+                  "hsl(var(--primary))",
+                  "hsl(var(--success))",
+                  "#f59e0b",
+                  "#ec4899",
+                  "#8b5cf6",
+                ][i % 5],
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {saving && (
+        <div className="flex items-center gap-3 text-sm text-foreground/50">
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Saving your snapshot...
+        </div>
+      )}
+
+      {saved && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.6 }}
+          className="flex flex-col items-center gap-3"
+        >
+          <div className="flex items-center gap-2 text-sm text-success">
+            <CheckCircle2 className="h-4 w-4" />
+            Snapshot saved successfully
+          </div>
+          <Button onClick={onGoToDashboard} className="mt-2">
+            Go to Dashboard
+          </Button>
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/onboarding/WelcomeStep.tsx
+++ b/app/src/components/onboarding/WelcomeStep.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { Zap, ClipboardList } from "lucide-react";
+
+export type OnboardingPath = "quick" | "complete";
+
+interface WelcomeStepProps {
+  onSelectPath: (path: OnboardingPath) => void;
+  onDismiss: () => void;
+}
+
+export function WelcomeStep({ onSelectPath, onDismiss }: WelcomeStepProps) {
+  return (
+    <div className="flex flex-col items-center text-center">
+      <h1 className="mb-3 text-2xl font-semibold leading-tight text-foreground sm:text-3xl">
+        You&apos;ve taken a great step toward building wealth.
+        <br />
+        Let&apos;s see where you stand today.
+      </h1>
+      <p className="mb-10 text-sm text-foreground/50">
+        Both paths end with your net worth number. You can always add more later
+        from the Snapshot page.
+      </p>
+
+      <div className="grid w-full gap-4 sm:grid-cols-2">
+        <motion.button
+          whileHover={{ scale: 1.02, y: -2 }}
+          whileTap={{ scale: 0.97 }}
+          onClick={() => onSelectPath("quick")}
+          className="group flex flex-col items-center gap-3 rounded-2xl border border-primary/30 bg-primary/5 p-6 text-left transition-colors hover:bg-primary/10 hover:border-primary/50"
+        >
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-primary/30 bg-primary/10">
+            <Zap className="h-6 w-6 text-primary" />
+          </div>
+          <div className="text-center">
+            <p className="text-base font-semibold text-foreground">
+              Quick Start
+            </p>
+            <p className="mt-1 text-xs text-foreground/45">
+              ~2 min · Savings, loans & credit cards
+            </p>
+          </div>
+        </motion.button>
+
+        <motion.button
+          whileHover={{ scale: 1.02, y: -2 }}
+          whileTap={{ scale: 0.97 }}
+          onClick={() => onSelectPath("complete")}
+          className="group flex flex-col items-center gap-3 rounded-2xl border border-white/10 bg-white/[0.02] p-6 text-left transition-colors hover:bg-white/[0.04] hover:border-white/20"
+        >
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-white/10 bg-white/5">
+            <ClipboardList className="h-6 w-6 text-foreground/60" />
+          </div>
+          <div className="text-center">
+            <p className="text-base font-semibold text-foreground">
+              Complete Picture
+            </p>
+            <p className="mt-1 text-xs text-foreground/45">
+              ~5 min · All assets & liabilities
+            </p>
+          </div>
+        </motion.button>
+      </div>
+
+      <motion.button
+        whileHover={{ scale: 1.015 }}
+        whileTap={{ scale: 0.97 }}
+        onClick={onDismiss}
+        className="mt-8 text-sm font-medium text-foreground/40 transition-colors hover:text-foreground/60"
+      >
+        I&apos;ll do this later
+      </motion.button>
+    </div>
+  );
+}

--- a/app/src/hooks/useBanks.ts
+++ b/app/src/hooks/useBanks.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export interface Bank {
+  id: string;
+  name: string;
+}
+
+export function useBanks() {
+  const [banks, setBanks] = useState<Bank[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/banks")
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch banks");
+        return res.json();
+      })
+      .then((data) => {
+        if (!cancelled) {
+          setBanks(data.banks);
+          setLoaded(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { banks, loaded };
+}

--- a/app/src/hooks/useStatements.ts
+++ b/app/src/hooks/useStatements.ts
@@ -78,5 +78,11 @@ export function useStatements() {
     setStatements((prev) => prev.filter((s) => s.id !== id));
   }, []);
 
-  return { statements, addStatement, bulkAddStatements, updateStatement, deleteStatement, loaded };
+  const deleteAllStatements = useCallback(async () => {
+    const res = await fetch("/api/statements", { method: "DELETE" });
+    if (!res.ok) throw new Error("Failed to delete all statements");
+    setStatements([]);
+  }, []);
+
+  return { statements, addStatement, bulkAddStatements, updateStatement, deleteStatement, deleteAllStatements, loaded };
 }

--- a/app/supabase-popular-banks-migration.sql
+++ b/app/supabase-popular-banks-migration.sql
@@ -1,0 +1,34 @@
+-- Supabase Postgres migration: popular_banks reference table
+-- Run this in the Supabase SQL Editor
+
+-- =========================================================================
+-- popular_banks (public reference data — no RLS needed)
+-- =========================================================================
+CREATE TABLE IF NOT EXISTS popular_banks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL UNIQUE,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_popular_banks_sort ON popular_banks(sort_order);
+
+-- =========================================================================
+-- Seed data: 14 popular Indian banks
+-- =========================================================================
+INSERT INTO popular_banks (name, sort_order) VALUES
+  ('SBI', 1),
+  ('HDFC Bank', 2),
+  ('ICICI Bank', 3),
+  ('Axis Bank', 4),
+  ('Kotak Mahindra Bank', 5),
+  ('Bank of Baroda', 6),
+  ('PNB', 7),
+  ('Canara Bank', 8),
+  ('Union Bank', 9),
+  ('IndusInd Bank', 10),
+  ('IDFC First Bank', 11),
+  ('Yes Bank', 12),
+  ('Federal Bank', 13),
+  ('Bank of India', 14)
+ON CONFLICT (name) DO NOTHING;

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-18

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/design.md
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/design.md
@@ -1,0 +1,76 @@
+## Context
+
+New users (zero snapshots) currently see `FirstSnapshotOnboarding` — a static welcome card that links to `/dashboard/snapshot`. This requires a context switch and self-guided form filling. The onboarding-improvement spec calls for replacing it with an in-place multi-step wizard that captures the first balance sheet and auto-saves it as a snapshot.
+
+**Current flow**: Dashboard → static card → link to `/dashboard/snapshot` → manual form → come back  
+**New flow**: Dashboard → guided wizard (7 steps) → auto-saved snapshot → dashboard with data
+
+The wizard reuses existing data hooks (`useStatements`, `useNetWorthHistory`) and the `StatementEntry` type. The only schema addition is a small `popular_banks` reference table for the bank picker.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace `FirstSnapshotOnboarding` with a multi-step wizard that captures the first snapshot in-place
+- Support two paths: Quick Start (3 steps) and Complete Picture (7 steps)
+- Auto-save entries and snapshot on completion
+- Maintain the "I'll do this later" dismiss behavior
+- Use existing UI primitives (shadcn/ui, framer-motion, Lucide, TailwindCSS)
+
+**Non-Goals:**
+- Mobile (Expo/React Native) version — follow-up change
+- Editing entries within the wizard — users edit later on the Snapshot page
+- Ownership percentage input — defaults to 100
+- Changes to the `StatementEntry` schema or API endpoints
+- Replacing the full Snapshot page form — wizard is onboarding only
+
+## Decisions
+
+### 1. Component architecture: parent wizard + step sub-components
+
+**Choice**: One parent `OnboardingWizard` component that manages state and step navigation, with each step as a separate sub-component under `app/src/components/onboarding/`.
+
+**Rationale**: Each step has distinct form logic (bank pickers, type pickers, amount inputs). Keeping them as separate files keeps each under ~100 lines and makes testing straightforward. The parent holds the unified entries array and orchestrates transitions.
+
+**Alternative considered**: Single monolithic component with switch/case. Rejected — would be 500+ lines and hard to maintain.
+
+### 2. State management: local state in parent, persist on final save only
+
+**Choice**: The parent component holds a `StatementEntry[]` array in React state. Entries accumulate as the user progresses through steps. On the final "Done" step, everything is saved in one batch via `bulkAddStatements` + `saveSnapshot`.
+
+**Rationale**: Avoids partial saves if the user abandons mid-wizard. The existing hooks already support bulk operations. No need for intermediate persistence since the wizard is a single session.
+
+**Alternative considered**: Save per-step to the API. Rejected — creates orphaned entries if user abandons, and adds unnecessary network calls.
+
+### 3. Quick Start vs Complete Picture: step filtering, not separate flows
+
+**Choice**: Define all steps in an ordered array with a `quickStart: boolean` flag. The selected path filters which steps to render. Both paths share the same step components and summary logic.
+
+**Rationale**: Eliminates code duplication. Adding/removing steps from either path is a config change. The step indicator adjusts dynamically based on the filtered step count.
+
+### 4. Bank picker: DB-backed reference table + "Other" with free-text fallback
+
+**Choice**: Create a `popular_banks` table in Supabase with columns `id`, `name`, and `sort_order`. Expose via `GET /api/banks` and a `useBanks` hook. The bank savings step fetches the list on mount and renders a selectable picker with an "Other" option that reveals a text input.
+
+**Rationale**: Storing banks in the DB means adding/removing banks is a simple DB insert — no code deployment needed. The table is public reference data (no user_id, no RLS required). The initial seed contains the 14 popular Indian banks. A `sort_order` column allows controlling display order.
+
+**Alternative considered**: Hardcoded `POPULAR_BANKS` constant in `types/index.ts`. Rejected — requires a code change and deployment to add a new bank, which is unnecessary friction for reference data.
+
+### 5. Summary step: compute locally, save via existing hooks
+
+**Choice**: On the summary step, call `computeTotals` from `lib/computations.ts` on the accumulated entries to display totals. Then call `bulkAddStatements` followed by `saveSnapshot` with today's date.
+
+**Rationale**: Reuses existing computation logic. The two-call pattern (add entries, then save snapshot) matches how the existing snapshot page works.
+
+### 6. Step transitions: framer-motion AnimatePresence with slide direction
+
+**Choice**: Wrap steps in `AnimatePresence` with a directional slide (left for forward, right for back). Use `motion.div` with `key={currentStepIndex}` for proper exit/enter animations.
+
+**Rationale**: Consistent with existing app animations. Provides clear spatial navigation metaphor.
+
+## Risks / Trade-offs
+
+- **Large component surface area** → Mitigated by breaking into sub-components and keeping step logic isolated.
+- **User abandons mid-wizard with unsaved data** → Acceptable — no partial saves means no cleanup needed. The wizard reappears on next visit until dismissed.
+- **Bank list fetch adds a network call** → Mitigated by caching in the `useBanks` hook (fetch once, reuse). The list is small (~15 rows) so latency is negligible. The "Other" option covers gaps if the fetch fails.
+- **Auto-save failure on completion** → Show error toast with retry button. Don't navigate away until save succeeds.
+- **Confetti/animation library** → Use CSS-based confetti or a lightweight package (e.g., `canvas-confetti`) to avoid bloat. If not already in deps, a simple CSS animation suffices.

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/proposal.md
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+New users who land on the dashboard see a static welcome card (`FirstSnapshotOnboarding`) that links them away to the full Snapshot form page. This creates a cold-start gap: users must context-switch to a separate page, figure out the form on their own, and come back. Drop-off at this stage is high because the first interaction feels like work, not guidance. A guided, multi-step onboarding wizard that captures the first balance sheet in-place will dramatically improve activation — users get their net worth number within minutes without leaving the dashboard context.
+
+## What Changes
+
+- **Replace `FirstSnapshotOnboarding`** with a new multi-step onboarding wizard component that walks users through capturing their first financial snapshot step-by-step.
+- **Two onboarding paths**: Quick Start (~2 min, savings + loans + credit cards) and Complete Picture (~5 min, all asset/liability categories).
+- **Per-step guided forms**: Bank savings, deposits/PF, investments, property/vehicles, loans, credit cards — each with an "add another" loop, skip option, and conversational headlines.
+- **Auto-save on completion**: The wizard computes totals and saves the first snapshot automatically, then shows a celebratory summary with net worth breakdown.
+- **Add `popular_banks` reference table** in Supabase with a `GET /api/banks` endpoint and `useBanks` hook, so the bank list is DB-managed and new banks can be added without code changes.
+- **Progress bar & back navigation** across wizard steps.
+- **Preserve dismiss behavior**: "I'll do this later" option retained with same `onDismiss` semantics.
+
+## Capabilities
+
+### New Capabilities
+- `onboarding-wizard`: Multi-step guided onboarding wizard that replaces the static first-snapshot card, supports Quick Start / Complete Picture paths, collects asset & liability entries via friendly forms, and auto-saves the first snapshot.
+
+### Modified Capabilities
+- `dashboard-hub`: The dashboard page will swap `FirstSnapshotOnboarding` for the new onboarding wizard component (same trigger condition: `allLoaded && !hasSnapshots && !dismissed`).
+
+## Impact
+
+- **Components**: `FirstSnapshotOnboarding.tsx` replaced by new wizard component(s) under `app/src/components/`. The old component can be removed.
+- **Dashboard page**: `app/src/app/dashboard/page.tsx` import and render updated to use the new wizard.
+- **Database**: New `popular_banks` table in Supabase (public read, no RLS needed — reference data). Seeded with the initial 14 banks.
+- **API**: New `GET /api/banks` route to fetch the bank list.
+- **Hooks**: New `useBanks` hook. Existing `useStatements` (`bulkAddStatements`), `useNetWorthHistory` (`saveSnapshot`), `useUserProfile` consumed read-only — no changes to existing APIs.
+- **Dependencies**: Uses existing shadcn/ui, framer-motion, Lucide, TailwindCSS. No new packages required.
+- **Statement schema unchanged**: All entries map to the existing `StatementEntry` type and `statements` table.

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/specs/dashboard-hub/spec.md
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/specs/dashboard-hub/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Dashboard shows onboarding wizard for zero-snapshot users
+The system SHALL display the onboarding wizard component instead of the standard dashboard hub when the authenticated user has zero snapshots and has not dismissed the onboarding prompt. The trigger condition SHALL be `allLoaded && !hasSnapshots && !dismissed`, matching the existing conditional render location.
+
+#### Scenario: New user sees onboarding wizard
+- **WHEN** an authenticated user with zero snapshots and no dismissal navigates to `/dashboard`
+- **THEN** the system SHALL render the `OnboardingWizard` component in place of the standard dashboard content
+
+#### Scenario: User with snapshots sees standard dashboard
+- **WHEN** an authenticated user with one or more snapshots navigates to `/dashboard`
+- **THEN** the system SHALL render the standard dashboard hub (not the wizard)
+
+#### Scenario: FirstSnapshotOnboarding component is replaced
+- **WHEN** the dashboard page is rendered for a zero-snapshot user
+- **THEN** the system SHALL render `OnboardingWizard` instead of the former `FirstSnapshotOnboarding` component

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/specs/onboarding-wizard/spec.md
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/specs/onboarding-wizard/spec.md
@@ -1,0 +1,153 @@
+## ADDED Requirements
+
+### Requirement: Onboarding wizard renders for new users
+The system SHALL display the onboarding wizard in place of the regular dashboard when the user has zero snapshots and has not dismissed the wizard.
+
+#### Scenario: New user sees wizard
+- **WHEN** an authenticated user with zero snapshots navigates to `/dashboard`
+- **THEN** the system SHALL display the onboarding wizard instead of the standard dashboard hub
+
+#### Scenario: Dismissed user sees dashboard
+- **WHEN** an authenticated user dismisses the wizard via "I'll do this later"
+- **THEN** the system SHALL hide the wizard and display the standard dashboard hub (empty state)
+
+### Requirement: Welcome step offers two onboarding paths
+The system SHALL display a welcome step with headline "You've taken a great step toward building wealth. Let's see where you stand today." and two path options: Quick Start (~2 min) and Complete Picture (~5 min).
+
+#### Scenario: User selects Quick Start
+- **WHEN** user selects the Quick Start path
+- **THEN** the wizard SHALL proceed through only Steps 1, 5, and 6 (Bank Savings, Loans, Credit Cards)
+
+#### Scenario: User selects Complete Picture
+- **WHEN** user selects the Complete Picture path
+- **THEN** the wizard SHALL proceed through all steps (Steps 1–6)
+
+### Requirement: Bank Savings step collects savings accounts
+The system SHALL display a Bank Savings step with headline "Let's start with your bank savings" that allows the user to add one or more savings accounts, each with a bank picker (fetched from the `popular_banks` DB table via `useBanks` hook + "Other" free-text) and closing balance amount.
+
+#### Scenario: User adds a savings account
+- **WHEN** user selects a bank from the picker and enters a closing balance
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Savings Bank Account"`, `category: "asset"`, `description` set to the bank name, and `ownershipPercentage: 100`
+
+#### Scenario: User adds multiple accounts
+- **WHEN** user clicks "Add another account" after filling an account
+- **THEN** the system SHALL display a new empty account form row
+
+#### Scenario: User skips bank savings
+- **WHEN** user clicks "I don't have any" or the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero savings entries
+
+### Requirement: Deposits & Provident Fund step collects deposit entries
+The system SHALL display a Deposits & PF step (Complete Picture only) with headline "Any fixed deposits or provident fund?" and a type picker for Fixed Deposit, PPF, and EPF, with optional description and amount.
+
+#### Scenario: User adds a fixed deposit
+- **WHEN** user selects "Fixed Deposit" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Fixed Deposit"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User adds EPF
+- **WHEN** user selects "EPF" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Other Asset"`, `description: "EPF"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips deposits
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero deposit entries
+
+### Requirement: Investments step collects investment entries
+The system SHALL display an Investments step (Complete Picture only) with headline "Any investments?" and a type picker for Mutual Fund, Stock Holdings, and Gold/Jewellery, with optional description and amount.
+
+#### Scenario: User adds a mutual fund
+- **WHEN** user selects "Mutual Fund" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Mutual Fund"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips investments
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero investment entries
+
+### Requirement: Property & Vehicles step collects property and vehicle entries
+The system SHALL display a Property & Vehicles step (Complete Picture only) with headline "Do you own any property or vehicles?" and a type picker for Real Estate and Vehicle, with description and fair market value.
+
+#### Scenario: User adds real estate
+- **WHEN** user selects "Real Estate" type, enters a description and value
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Real Estate"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User adds a vehicle
+- **WHEN** user selects "Vehicle" type, enters description and value
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Other Asset"`, `description` containing vehicle info, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips property
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero property entries
+
+### Requirement: Loans step collects loan entries
+The system SHALL display a Loans step with headline "Now let's record any loans" and a type picker for Home Loan, Personal Loan, Car Loan, and Education Loan, with optional description and outstanding amount.
+
+#### Scenario: User adds a home loan
+- **WHEN** user selects "Home Loan" type and enters an outstanding amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Home Loan"`, `category: "liability"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips loans
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero loan entries
+
+### Requirement: Credit Cards step collects credit card balances
+The system SHALL display a Credit Cards step with headline "Any credit card balances you're carrying?" and subtitle "Only outstanding balance, not your credit limit", allowing the user to enter a card description and outstanding amount.
+
+#### Scenario: User adds a credit card balance
+- **WHEN** user enters a card description (e.g., "HDFC Regalia") and outstanding amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Credit Card Outstanding"`, `category: "liability"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips credit cards
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the summary step with zero credit card entries
+
+### Requirement: Summary step displays totals and auto-saves snapshot
+The system SHALL display a summary step with headline "Here's your financial snapshot!" showing total assets, total liabilities, and net worth computed via `computeTotals`. The system SHALL first delete all existing statements via `deleteAllStatements`, then save the collected entries via `bulkAddStatements`, and create a snapshot via `saveSnapshot` with today's date.
+
+#### Scenario: Summary displays computed totals
+- **WHEN** user reaches the summary step
+- **THEN** the system SHALL display total assets, total liabilities, and net worth using `computeTotals`
+
+#### Scenario: Snapshot is auto-saved
+- **WHEN** the summary step is displayed
+- **THEN** the system SHALL call `deleteAllStatements` to clear any pre-existing statements, then `bulkAddStatements` with all collected entries, and `saveSnapshot` with the computed totals and today's date
+
+#### Scenario: Celebratory moment on completion
+- **WHEN** the snapshot is successfully saved
+- **THEN** the system SHALL display a celebratory animation (confetti or similar)
+
+#### Scenario: User navigates to dashboard after completion
+- **WHEN** user clicks "Go to Dashboard" on the summary step
+- **THEN** the system SHALL navigate to `/dashboard` which now displays the standard dashboard with the saved snapshot data
+
+### Requirement: Wizard has progress indicator and back navigation
+The system SHALL display a progress bar or step indicator showing the user's position in the wizard. The wizard SHALL support back navigation to revisit previous steps without losing entered data.
+
+#### Scenario: Progress bar reflects current step
+- **WHEN** user is on step 3 of 7 in Complete Picture mode
+- **THEN** the progress indicator SHALL show step 3 of 7 as active
+
+#### Scenario: User navigates back
+- **WHEN** user clicks the back button on any step after the welcome step
+- **THEN** the wizard SHALL return to the previous step with previously entered data preserved
+
+### Requirement: Popular banks are stored in the database
+The system SHALL store popular bank names in a `popular_banks` Supabase table with columns `id` (UUID), `name` (TEXT, UNIQUE), `sort_order` (INTEGER), and `created_at` (TIMESTAMPTZ). The table SHALL be seeded with 14 Indian banks: SBI, HDFC Bank, ICICI Bank, Axis Bank, Kotak Mahindra Bank, Bank of Baroda, PNB, Canara Bank, Union Bank, IndusInd Bank, IDFC First Bank, Yes Bank, Federal Bank, and Bank of India.
+
+#### Scenario: Banks are fetched via API
+- **WHEN** the onboarding wizard bank savings step renders
+- **THEN** it SHALL fetch the bank list from `GET /api/banks` (via `useBanks` hook) ordered by `sort_order` and display them in the bank picker
+
+#### Scenario: Adding a new bank requires only a DB insert
+- **WHEN** an admin inserts a new row into the `popular_banks` table
+- **THEN** the new bank SHALL appear in the bank picker on next page load without any code deployment
+
+#### Scenario: Bank fetch failure falls back gracefully
+- **WHEN** the `GET /api/banks` request fails
+- **THEN** the bank picker SHALL still allow the user to type a bank name via the "Other" free-text input
+
+### Requirement: Each wizard step has a skip option
+The system SHALL provide a skip option ("I don't have any" or equivalent) on every asset/liability collection step, allowing the user to proceed without adding entries for that category.
+
+#### Scenario: Skip preserves existing entries
+- **WHEN** user skips a step
+- **THEN** previously collected entries from other steps SHALL remain intact and the wizard SHALL advance to the next step

--- a/openspec/changes/archive/2026-04-19-onboarding-wizard/tasks.md
+++ b/openspec/changes/archive/2026-04-19-onboarding-wizard/tasks.md
@@ -1,0 +1,38 @@
+## 1. Database & API for Popular Banks
+
+- [x] 1.1 Create `popular_banks` table migration SQL: columns `id` (UUID, PK), `name` (TEXT, NOT NULL, UNIQUE), `sort_order` (INTEGER, NOT NULL DEFAULT 0), `created_at` (TIMESTAMPTZ, DEFAULT now()). No RLS needed — public reference data.
+- [x] 1.2 Create seed SQL to insert the initial 14 banks: SBI, HDFC Bank, ICICI Bank, Axis Bank, Kotak Mahindra Bank, Bank of Baroda, PNB, Canara Bank, Union Bank, IndusInd Bank, IDFC First Bank, Yes Bank, Federal Bank, Bank of India — with sort_order 1–14
+- [x] 1.3 Create `GET /api/banks` route that queries `popular_banks` table ordered by `sort_order` and returns `{ banks: { id, name }[] }`
+- [x] 1.4 Create `useBanks` hook in `app/src/hooks/useBanks.ts` that fetches `/api/banks` on mount and returns `{ banks, loaded }`
+
+## 2. Wizard Infrastructure
+
+- [x] 2.1 Create `app/src/components/onboarding/` directory and the parent `OnboardingWizard.tsx` component with step state management, entries accumulation array, Quick Start / Complete Picture path filtering, progress bar, and back/forward navigation
+- [x] 2.2 Define the step configuration array with `id`, `component`, `headline`, and `quickStart` flag for each step
+
+## 3. Wizard Step Components
+
+- [x] 3.1 Create `WelcomeStep.tsx` — welcome headline, Quick Start and Complete Picture path selection buttons, "I'll do this later" dismiss option
+- [x] 3.2 Create `BankSavingsStep.tsx` — bank picker using `useBanks` hook (select + "Other" free-text fallback), closing balance input, add-another loop, skip option
+- [x] 3.3 Create `DepositsStep.tsx` — type picker (Fixed Deposit, PPF, EPF), optional description, amount input, add-another loop, skip option
+- [x] 3.4 Create `InvestmentsStep.tsx` — type picker (Mutual Fund, Stock Holdings, Gold/Jewellery), optional description, amount input, add-another loop, skip option
+- [x] 3.5 Create `PropertyStep.tsx` — type picker (Real Estate, Vehicle), description, fair market value input, add-another loop, skip option
+- [x] 3.6 Create `LoansStep.tsx` — type picker (Home Loan, Personal Loan, Car Loan, Education Loan), optional description, outstanding amount input, add-another loop, skip option
+- [x] 3.7 Create `CreditCardsStep.tsx` — card description input, outstanding amount input, subtitle hint "Only outstanding balance, not your credit limit", add-another loop, skip option
+
+## 4. Summary & Save
+
+- [x] 4.1 Create `SummaryStep.tsx` — display total assets, total liabilities, net worth using `computeTotals`, celebratory animation, "Go to Dashboard" CTA
+- [x] 4.2 Implement auto-save logic in `SummaryStep` or parent: call `bulkAddStatements` with all collected entries, then `saveSnapshot` with computed totals and today's date, with error handling and retry
+
+## 5. Dashboard Integration
+
+- [x] 5.1 Update `app/src/app/dashboard/page.tsx` to import `OnboardingWizard` instead of `FirstSnapshotOnboarding`, pass `firstName`, `onDismiss`, and required hooks (`useStatements`, `useNetWorthHistory`) as props or consume them inside the wizard
+- [x] 5.2 Remove or deprecate `FirstSnapshotOnboarding.tsx` after verifying the wizard is wired in
+
+## 6. Polish & Verification
+
+- [x] 6.1 Add framer-motion `AnimatePresence` transitions between wizard steps (directional slide left/right)
+- [x] 6.2 Verify step indicator updates correctly for both Quick Start (3 steps + welcome + summary) and Complete Picture (6 steps + welcome + summary) paths
+- [x] 6.3 Verify all `StatementEntry` mappings produce correct `statementType`, `category`, `description`, and `ownershipPercentage: 100` for every entry type
+- [x] 6.4 Test end-to-end: complete wizard → entries saved → snapshot created → dashboard renders with data

--- a/openspec/specs/dashboard-hub/spec.md
+++ b/openspec/specs/dashboard-hub/spec.md
@@ -115,3 +115,18 @@ The system SHALL provide a shared layout for all `/dashboard/*` pages with a hea
 #### Scenario: Sub-page shows back navigation
 - **WHEN** user is on any dashboard sub-page (e.g., `/dashboard/wealth-tracker`)
 - **THEN** the system SHALL display a header with a link back to the dashboard hub
+
+### Requirement: Dashboard shows onboarding wizard for zero-snapshot users
+The system SHALL display the onboarding wizard component instead of the standard dashboard hub when the authenticated user has zero snapshots and has not dismissed the onboarding prompt. The trigger condition SHALL be `allLoaded && !hasSnapshots && !dismissed`, matching the existing conditional render location.
+
+#### Scenario: New user sees onboarding wizard
+- **WHEN** an authenticated user with zero snapshots and no dismissal navigates to `/dashboard`
+- **THEN** the system SHALL render the `OnboardingWizard` component in place of the standard dashboard content
+
+#### Scenario: User with snapshots sees standard dashboard
+- **WHEN** an authenticated user with one or more snapshots navigates to `/dashboard`
+- **THEN** the system SHALL render the standard dashboard hub (not the wizard)
+
+#### Scenario: FirstSnapshotOnboarding component is replaced
+- **WHEN** the dashboard page is rendered for a zero-snapshot user
+- **THEN** the system SHALL render `OnboardingWizard` instead of the former `FirstSnapshotOnboarding` component

--- a/openspec/specs/onboarding-wizard/spec.md
+++ b/openspec/specs/onboarding-wizard/spec.md
@@ -1,0 +1,159 @@
+# Onboarding Wizard
+
+## Purpose
+
+This specification defines the requirements for the onboarding wizard that guides new users through capturing their first financial snapshot via a multi-step wizard.
+
+## Requirements
+
+### Requirement: Onboarding wizard renders for new users
+The system SHALL display the onboarding wizard in place of the regular dashboard when the user has zero snapshots and has not dismissed the wizard.
+
+#### Scenario: New user sees wizard
+- **WHEN** an authenticated user with zero snapshots navigates to `/dashboard`
+- **THEN** the system SHALL display the onboarding wizard instead of the standard dashboard hub
+
+#### Scenario: Dismissed user sees dashboard
+- **WHEN** an authenticated user dismisses the wizard via "I'll do this later"
+- **THEN** the system SHALL hide the wizard and display the standard dashboard hub (empty state)
+
+### Requirement: Welcome step offers two onboarding paths
+The system SHALL display a welcome step with headline "You've taken a great step toward building wealth. Let's see where you stand today." and two path options: Quick Start (~2 min) and Complete Picture (~5 min).
+
+#### Scenario: User selects Quick Start
+- **WHEN** user selects the Quick Start path
+- **THEN** the wizard SHALL proceed through only Steps 1, 5, and 6 (Bank Savings, Loans, Credit Cards)
+
+#### Scenario: User selects Complete Picture
+- **WHEN** user selects the Complete Picture path
+- **THEN** the wizard SHALL proceed through all steps (Steps 1–6)
+
+### Requirement: Bank Savings step collects savings accounts
+The system SHALL display a Bank Savings step with headline "Let's start with your bank savings" that allows the user to add one or more savings accounts, each with a bank picker (fetched from the `popular_banks` DB table via `useBanks` hook + "Other" free-text) and closing balance amount.
+
+#### Scenario: User adds a savings account
+- **WHEN** user selects a bank from the picker and enters a closing balance
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Savings Bank Account"`, `category: "asset"`, `description` set to the bank name, and `ownershipPercentage: 100`
+
+#### Scenario: User adds multiple accounts
+- **WHEN** user clicks "Add another account" after filling an account
+- **THEN** the system SHALL display a new empty account form row
+
+#### Scenario: User skips bank savings
+- **WHEN** user clicks "I don't have any" or the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero savings entries
+
+### Requirement: Deposits & Provident Fund step collects deposit entries
+The system SHALL display a Deposits & PF step (Complete Picture only) with headline "Any fixed deposits or provident fund?" and a type picker for Fixed Deposit, PPF, and EPF, with optional description and amount.
+
+#### Scenario: User adds a fixed deposit
+- **WHEN** user selects "Fixed Deposit" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Fixed Deposit"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User adds EPF
+- **WHEN** user selects "EPF" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Other Asset"`, `description: "EPF"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips deposits
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero deposit entries
+
+### Requirement: Investments step collects investment entries
+The system SHALL display an Investments step (Complete Picture only) with headline "Any investments?" and a type picker for Mutual Fund, Stock Holdings, and Gold/Jewellery, with optional description and amount.
+
+#### Scenario: User adds a mutual fund
+- **WHEN** user selects "Mutual Fund" type and enters an amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Mutual Fund"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips investments
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero investment entries
+
+### Requirement: Property & Vehicles step collects property and vehicle entries
+The system SHALL display a Property & Vehicles step (Complete Picture only) with headline "Do you own any property or vehicles?" and a type picker for Real Estate and Vehicle, with description and fair market value.
+
+#### Scenario: User adds real estate
+- **WHEN** user selects "Real Estate" type, enters a description and value
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Real Estate"`, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User adds a vehicle
+- **WHEN** user selects "Vehicle" type, enters description and value
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Other Asset"`, `description` containing vehicle info, `category: "asset"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips property
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero property entries
+
+### Requirement: Loans step collects loan entries
+The system SHALL display a Loans step with headline "Now let's record any loans" and a type picker for Home Loan, Personal Loan, Car Loan, and Education Loan, with optional description and outstanding amount.
+
+#### Scenario: User adds a home loan
+- **WHEN** user selects "Home Loan" type and enters an outstanding amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Home Loan"`, `category: "liability"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips loans
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the next step with zero loan entries
+
+### Requirement: Credit Cards step collects credit card balances
+The system SHALL display a Credit Cards step with headline "Any credit card balances you're carrying?" and subtitle "Only outstanding balance, not your credit limit", allowing the user to enter a card description and outstanding amount.
+
+#### Scenario: User adds a credit card balance
+- **WHEN** user enters a card description (e.g., "HDFC Regalia") and outstanding amount
+- **THEN** the system SHALL create a `StatementEntry` with `statementType: "Credit Card Outstanding"`, `category: "liability"`, and `ownershipPercentage: 100`
+
+#### Scenario: User skips credit cards
+- **WHEN** user clicks the skip option
+- **THEN** the wizard SHALL proceed to the summary step with zero credit card entries
+
+### Requirement: Summary step displays totals and auto-saves snapshot
+The system SHALL display a summary step with headline "Here's your financial snapshot!" showing total assets, total liabilities, and net worth computed via `computeTotals`. The system SHALL first delete all existing statements via `deleteAllStatements`, then save the collected entries via `bulkAddStatements`, and create a snapshot via `saveSnapshot` with today's date.
+
+#### Scenario: Summary displays computed totals
+- **WHEN** user reaches the summary step
+- **THEN** the system SHALL display total assets, total liabilities, and net worth using `computeTotals`
+
+#### Scenario: Snapshot is auto-saved
+- **WHEN** the summary step is displayed
+- **THEN** the system SHALL call `deleteAllStatements` to clear any pre-existing statements, then `bulkAddStatements` with all collected entries, and `saveSnapshot` with the computed totals and today's date
+
+#### Scenario: Celebratory moment on completion
+- **WHEN** the snapshot is successfully saved
+- **THEN** the system SHALL display a celebratory animation (confetti or similar)
+
+#### Scenario: User navigates to dashboard after completion
+- **WHEN** user clicks "Go to Dashboard" on the summary step
+- **THEN** the system SHALL navigate to `/dashboard` which now displays the standard dashboard with the saved snapshot data
+
+### Requirement: Wizard has progress indicator and back navigation
+The system SHALL display a progress bar or step indicator showing the user's position in the wizard. The wizard SHALL support back navigation to revisit previous steps without losing entered data.
+
+#### Scenario: Progress bar reflects current step
+- **WHEN** user is on step 3 of 7 in Complete Picture mode
+- **THEN** the progress indicator SHALL show step 3 of 7 as active
+
+#### Scenario: User navigates back
+- **WHEN** user clicks the back button on any step after the welcome step
+- **THEN** the wizard SHALL return to the previous step with previously entered data preserved
+
+### Requirement: Popular banks are stored in the database
+The system SHALL store popular bank names in a `popular_banks` Supabase table with columns `id` (UUID), `name` (TEXT, UNIQUE), `sort_order` (INTEGER), and `created_at` (TIMESTAMPTZ). The table SHALL be seeded with 14 Indian banks: SBI, HDFC Bank, ICICI Bank, Axis Bank, Kotak Mahindra Bank, Bank of Baroda, PNB, Canara Bank, Union Bank, IndusInd Bank, IDFC First Bank, Yes Bank, Federal Bank, and Bank of India.
+
+#### Scenario: Banks are fetched via API
+- **WHEN** the onboarding wizard bank savings step renders
+- **THEN** it SHALL fetch the bank list from `GET /api/banks` (via `useBanks` hook) ordered by `sort_order` and display them in the bank picker
+
+#### Scenario: Adding a new bank requires only a DB insert
+- **WHEN** an admin inserts a new row into the `popular_banks` table
+- **THEN** the new bank SHALL appear in the bank picker on next page load without any code deployment
+
+#### Scenario: Bank fetch failure falls back gracefully
+- **WHEN** the `GET /api/banks` request fails
+- **THEN** the bank picker SHALL still allow the user to type a bank name via the "Other" free-text input
+
+### Requirement: Each wizard step has a skip option
+The system SHALL provide a skip option ("I don't have any" or equivalent) on every asset/liability collection step, allowing the user to proceed without adding entries for that category.
+
+#### Scenario: Skip preserves existing entries
+- **WHEN** user skips a step
+- **THEN** previously collected entries from other steps SHALL remain intact and the wizard SHALL advance to the next step


### PR DESCRIPTION
Features:
- Add multi-step onboarding wizard for new users (Quick Start/Complete Picture paths)
- Add popular_banks DB table with seed data and /api/banks endpoint
- Add useBanks hook to fetch bank list from DB
- Add wizard step components: Welcome, BankSavings, Deposits, Investments, Property, Loans, CreditCards, Summary
- Integrate OnboardingWizard into dashboard, replacing FirstSnapshotOnboarding
- Add AnimatePresence transitions between wizard steps
- Wizard clears existing statements before saving new ones to prevent stale data

Bug fixes:
- Fix DELETE /api/statements/[id] and /api/snapshots/[id] - removed unreliable count check that caused false 404s
- Fix Snapshot page delete persistence - buffer deletions locally until Save Snapshot is clicked
- Fix net worth not updating on delete by using plain array instead of Set for pending deletions

Specs:
- Sync onboarding-wizard delta spec to main specs (new capability)
- Sync dashboard-hub delta spec to main specs (add onboarding wizard requirement)
- Archive onboarding-wizard change to openspec/changes/archive/2026-04-19-onboarding-wizard/